### PR TITLE
Enable to log the number of expanded nodes

### DIFF
--- a/Entry.cpp
+++ b/Entry.cpp
@@ -9,6 +9,7 @@ std::vector<bool> map;
 std::vector<int> visited;
 std::vector<xyLoc> succ;
 int width, height;
+int expanded;
 
 void GetSuccessors(xyLoc s, std::vector<xyLoc> &neighbors);
 int GetIndex(xyLoc s);
@@ -35,6 +36,7 @@ void *PrepareForSearch(std::vector<bool> &bits, int w, int h, const char *filena
 
 bool GetPath(void *data, xyLoc s, xyLoc g, std::vector<xyLoc> &path)
 {
+    expanded = 0;
     assert((long)data == 13182);
     std::deque<xyLoc> q;
 
@@ -51,6 +53,7 @@ bool GetPath(void *data, xyLoc s, xyLoc g, std::vector<xyLoc> &path)
     while (q.size() > 0)
     {
         xyLoc next = q.front();
+        expanded++;
 
         q.pop_front();
         GetSuccessors(next, succ);

--- a/Entry.h
+++ b/Entry.h
@@ -5,6 +5,7 @@ struct xyLoc {
   int16_t y;
 };
 
+extern int expanded;
 void PreprocessMap(std::vector<bool> &bits, int width, int height, const char *filename);
 void *PrepareForSearch(std::vector<bool> &bits, int width, int height, const char *filename);
 bool GetPath(void *data, xyLoc s, xyLoc g, std::vector<xyLoc> &path);

--- a/main.cpp
+++ b/main.cpp
@@ -14,6 +14,7 @@ struct stats {
     std::vector<double> times;
     std::vector<xyLoc> path;
     std::vector<int> lengths;
+    int expanded_nodes;
 
     double GetTotalTime()
     {
@@ -154,6 +155,8 @@ int main(int argc, char **argv)
 
             experimentStats[x].times.push_back(t.GetElapsedTime());
             experimentStats[x].lengths.push_back(thePath.size());
+            if(!done)
+                experimentStats[x].expanded_nodes = expanded;
             for (unsigned int t = experimentStats[x].path.size(); t < thePath.size(); t++)
                 experimentStats[x].path.push_back(thePath[t]);
         } while (done == false);
@@ -162,9 +165,9 @@ int main(int argc, char **argv)
 
     for (unsigned int x = 0; x < experimentStats.size(); x++)
     {
-        printf("%s\ttotal-time\t%f\tmax-time-step\t%f\ttime-20-moves\t%f\ttotal-len\t%f\tsubopt\t%f\t", argv[3],
+        printf("%s\ttotal-time\t%f\tmax-time-step\t%f\ttime-20-moves\t%f\ttotal-len\t%f\tsubopt\t%f\texpanded_nodes\t%d\t", argv[3],
                experimentStats[x].GetTotalTime(), experimentStats[x].GetMaxTimestep(), experimentStats[x].Get20MoveTime(),
-               experimentStats[x].GetPathLength(), experimentStats[x].GetPathLength()/scen.GetNthExperiment(x).GetDistance());
+               experimentStats[x].GetPathLength(), experimentStats[x].GetPathLength()/scen.GetNthExperiment(x).GetDistance(), experimentStats[x].expanded_nodes);
         if (experimentStats[x].path.size() == 0 ||
                 (experimentStats[x].ValidatePath(width, height, mapData) &&
                  scen.GetNthExperiment(x).GetStartX() == experimentStats[x].path[0].x &&


### PR DESCRIPTION
**Summary**
- This PR enables to log the number of expanded nodes
- By using global variable, we can log the number. The reason why I use global variable is below
  - I don't want to change arguments of `GetPath`.
  - I don't want to log in `GetPath` because of its delay.


This PR closes #1 
